### PR TITLE
Import Order Fix

### DIFF
--- a/src/lib/landing/reviews.ts
+++ b/src/lib/landing/reviews.ts
@@ -1,5 +1,5 @@
-import { reviewSchema, type Review } from "@/types/landing/reviews";
 import { getLocale } from "next-intl/server";
+import { reviewSchema, type Review } from "@/types/landing/reviews";
 
 export async function getReviews(): Promise<Review[]> {
 	const locale = await getLocale();


### PR DESCRIPTION
# Import Order Fix

## Overview
Simple fix to maintain consistent import ordering in `reviews.ts`, following project conventions.

## Changes
- Reordered imports in `src/lib/landing/reviews.ts` to put external packages first (`next-intl`) followed by internal imports (`@/types`)