### PR TITLE
RPE Input Clearing Fix in 1RM Calculator

### DIFF
--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -189,7 +189,7 @@ const FormNumericField = <T extends FieldValues>({
 		<FormField
 			control={control}
 			name={name}
-			render={({ field: { value, onChange, ...props } }) => (
+			render={({ field: { onChange, ...props } }) => (
 				<FormItem>
 					<FormLabel>{label}</FormLabel>
 					<FormControl>
@@ -198,10 +198,10 @@ const FormNumericField = <T extends FieldValues>({
 							type="number"
 							min={min}
 							max={max}
-							value={value ?? ""}
 							onChange={(e) => {
-								const value = e.target.value === "" ? undefined : parseFloat(e.target.value);
-								onChange(value);
+								const inputValue = e.target.value;
+								const parsedValue = inputValue === "" ? inputValue : parseFloat(inputValue);
+								onChange(parsedValue);
 							}}
 						/>
 					</FormControl>

--- a/src/components/tools/one-rep-max/form.tsx
+++ b/src/components/tools/one-rep-max/form.tsx
@@ -20,7 +20,7 @@ export function OneRepMaxForm() {
 	const form = useForm<OneRepMaxFormValues>({
 		resolver: zodResolver(oneRepMaxSchema),
 		mode: "onChange",
-		defaultValues: { reps: undefined, rpe: 10, weight: undefined, method: "rpeChart" },
+		defaultValues: { method: "rpeChart", rpe: 10 },
 	});
 	const [oneRepMax, setOneRepMax] = useState<number | undefined>(undefined);
 
@@ -29,7 +29,7 @@ export function OneRepMaxForm() {
 
 	useEffect(() => {
 		if (!methodUsesRpe) {
-			form.setValue("rpe", 10);
+			form.setValue("rpe", 10, { shouldValidate: true });
 		}
 	}, [methodUsesRpe, form]);
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -5,6 +5,6 @@ export const requiredNumber = (
 	conditions: (schema: z.ZodNumber) => z.ZodNumber,
 ) =>
 	z
-		.union([z.number(), z.literal(undefined)])
-		.refine((val) => val !== undefined, { message: requiredMessage })
+		.union([z.number(), z.literal("")])
+		.refine((val) => val !== "", { message: requiredMessage })
 		.pipe(conditions(z.number()));


### PR DESCRIPTION
# RPE Input Clearing Fix in 1RM Calculator

## Issue
Fixes #21 - RPE input value couldn't be properly cleared and was causing validation issues when switching between calculation methods.

## Changes
- Update schema validation for RPE field to handle conditional requirements
- Add proper handling of empty string values in numeric inputs
- Ensure RPE field state is managed correctly when switching calculation methods

## Additional Notes
- RPE field is now properly validated based on the selected calculation method
- Empty string handling has been improved in numeric inputs
- Form state management has been optimized for conditional fields